### PR TITLE
Support custom extra cli arguments to Lf

### DIFF
--- a/autoload/lf.vim
+++ b/autoload/lf.vim
@@ -3,29 +3,44 @@ if exists('g:loaded_lf_autoload')
 endif
 let g:loaded_lf_autoload = 1
 
-function! lf#LF(path, edit_cmd)
+function! lf#LF(path, edit_cmd, extra_lf_args)
+  " To be used inside functions defined here
+  let s:edit_cmd = a:edit_cmd
+  " To revert back guioptions after changing them for Vim
   let oldguioptions = &guioptions
-  let s:oldlaststatus = &laststatus
+  " To save what files were chosen by lf
   let s:choice_file_path = tempname()
-  let s:mostLFArgs = 'lf -selection-path=' . s:choice_file_path . ' '
-  " TODO: Test if currentPath needs shell quoting...
-  let currentPath = expand(a:path)
+  let s:lfArgs = [
+          \ 'lf', '-selection-path=' . s:choice_file_path,
+          \] + a:extra_lf_args + [
+          \ fnameescape(expand(a:path))
+          \]
+  " Quote it in a shell safe manner
   if has('nvim')
-    " For internal usage - not needed by the API
-    let termopen_opts = { 'edit_cmd': a:edit_cmd }
+    " To be passed down to termopen
+    let termopen_opts = { }
     function! termopen_opts.on_exit(job_id, code, event)
       if filereadable(s:choice_file_path)
         for f in readfile(s:choice_file_path)
-          exec self.edit_cmd . ' ' . f
+          exec s:edit_cmd . f
         endfor
         call delete(s:choice_file_path)
       endif
       if a:code == 0
+        " Iterate open buffers and search for our terminal buffer - to delete
+        " it afterwards
+        for buf in getbufinfo()
+          if has_key(buf.variables, 'terminal_job_id') && buf.variables.terminal_job_id == a:job_id
+            let bufnr = buf.bufnr
+            break
+          endif
+        endfor
         if exists(":Bclose")
-          silent! Bclose! #
+          call execute('Bclose! ' . bufnr)
         elseif exists(":Bdelete")
-          silent! Bdelete! #
+          call execute('Bdelete! ' . bufnr)
         else
+          " See https://vi.stackexchange.com/a/25798/6411
           let v:errmsg = "lf.vim: Failed to close buffer lf buffer -" .
                   \ "No `:Bdelete` or `:Bclose` commands were found. You can implement either of them yourself, or install either of:\n" .
                   \ " - https://github.com/rbgrouleff/bclose.vim\n" .
@@ -35,11 +50,10 @@ function! lf#LF(path, edit_cmd)
       endif
     endfunction
     enew
-      " We want Lf to quit after it saves the selections
-      call termopen(s:mostLFArgs . '-command "map <right> push :open<enter>:quit<enter>" "' . currentPath . '"', termopen_opts)
+    " We want Lf to quit after it saves the selections
+    call termopen(s:lfArgs, termopen_opts)
     startinsert
   else
-    let s:edit_cmd = a:edit_cmd
     function! s:EditCallback()
       if filereadable(s:choice_file_path)
         for f in readfile(s:choice_file_path)
@@ -53,7 +67,7 @@ function! lf#LF(path, edit_cmd)
       " filetype detect
     endfunction
     set guioptions+=! " Make it work with MacVim
-    let buf = term_start(s:mostLFArgs . currentPath . '"', #{hidden: 1, term_finish: 'close'})
+    let buf = term_start(join(s:lfArgs, ' '), #{hidden: 1, term_finish: 'close'})
     let winid = popup_dialog(buf, #{minwidth: 150, minheight: 20, highlight: 'Normal'})
     let bufn = winbufnr(winid)
     exe 'autocmd! BufWinLeave <buffer='.bufn.'> call s:EditCallback()'

--- a/plugin/lf.vim
+++ b/plugin/lf.vim
@@ -6,7 +6,7 @@ let g:loaded_lf = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-command! -nargs=+ LF call lf#LF(<f-args>)
+command! -nargs=+ LF call lf#LF(<f-args>, [])
 nnoremap <Plug>LfEdit :LF %:p edit<CR>
 nnoremap <Plug>LfSplit :LF %:p split<CR>
 


### PR DESCRIPTION
And add comments.

@thezeroalpha this is a follow up to #1. Sorry again for not splitting this to smaller commits, but I'll note here the notable changes:

- Use `fnameescape(expand(a:path))` to put the filename in a safe manner in Lf's CLI.
- Use an array for better readability / compatibility of all cli args to Lf.
- Support custom extra cli arguments to Lf.