### PR TITLE
Fix loading of plugin under Neovim

### DIFF
--- a/plugin/lf.vim
+++ b/plugin/lf.vim
@@ -1,4 +1,4 @@
-if exists('g:loaded_lf') || &cp || v:version < 802
+if exists('g:loaded_lf') || &cp || (v:version < 802 && ! has('nvim'))
   finish
 endif
 let g:loaded_lf = 1


### PR DESCRIPTION
v:version evaluates to 800 on current versions of Neovim resulting in
the plugin failing to load. Slightly changing the logic to make the
plugin function.